### PR TITLE
position autosuggest correctly after scrolled down

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -5,14 +5,20 @@
 var h = require('hyperscript')
 var suggest = require('../')
 
-var textarea = h('textarea')
+var textarea = TA = h('textarea', {rows: 60, columns: 20})
 
-document.body.appendChild(h('style', 
-  '.suggest-box {position: fixed;}'
-+ '.suggest-box .selected {color: red;}'
+document.body.appendChild(h('style',
+  '.suggest-box .selected {color: red;}'
 ))
 
-document.body.appendChild(textarea)
+document.body.appendChild(h('div',
+  h('h1', 'suggestbox test'),
+  textarea,
+  h('p',
+    'type into the text area, and when you type "."',
+    'an autosuggest for DOM properties will be created'
+  )
+))
 
 suggest(textarea, {
   '.': function (word, cb) {
@@ -29,4 +35,5 @@ suggest(textarea, {
       }, ~~(Math.random()*200))
     }
 })
+
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "git://github.com/pfraze/suggest-box.git"
   },
   "dependencies": {
-    "hyperscript": "~1.4.2"
+    "hyperscript": "~1.4.2",
+    "textarea-caret-position": "^0.1.1"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
This fixes the autosuggest behavior in the the example (I was running it with [electro](https://npm.im/electro))

However, if you zoom in in patchwork it will slip upwards. But it works fine on the default zoom level.
