### PR TITLE
add stringify option, to handle non-string values

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ suggestBox(textarea, suggester, {
   cls: 'my-suggest-box' // optional, extra class for the suggest-box popup
 })
 ```
+### options
+* `cls` additional classes to set on the suggest box. appended to `'.suggestbox'+cls`. see syntax for [hyperscript classes](https://github.com/dominictarr/hyperscript#classes--id)
+* `stringify` a function called to map a selected value to a string. 
+
 
 ## suggestor
 
@@ -43,6 +47,10 @@ if there is an error, it will be logged.
     value: '@bob'              // value to insert once selected
 }
 ```
+
+when an item is selected. the value of the `value` property is inserted at the cursor.
+If `options.stringify` is provided, then `options.stringify(value)` is inserted (which means `.value` may be an object)
+otherwise `value` must be a string.
 
 can use `showBoth` to display image and title
 ``` js

--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ module.exports = function(el, choices, options) {
 
   var suggest = Suggester(choices)
 
+  var stringify = options.stringify || String
+
   var box = {
     input: el,
     choices: choices,
@@ -90,7 +92,7 @@ module.exports = function(el, choices, options) {
         var choice = this.filtered[this.selection]
         if (choice && choice.value) {
           // update the text under the cursor to have the current selection's value          var v = el.value
-          this.set(choice.value)
+          this.set(stringify(choice.value))
           // fire the suggestselect event
           el.dispatchEvent(new CustomEvent('suggestselect', { detail: choice }))
         }
@@ -215,21 +217,4 @@ function onkeydown(e) {
 function onblur(e) {
   this.deactivate()
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 


### PR DESCRIPTION
sometimes an app has several text entry points that require autosuggest.
(say, search bar, markdown editing, etc)

These may look up the same data, but it's quite possible that they insert it differently. this pull request adds a stringify function, which is called on `.selected.value`.

This makes it a simple change to reuse the same lookup code with different ways of rendering that selection.
