### PR TITLE
Make suggest-box smarter about placement on the screen

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -5,7 +5,9 @@
 var h = require('hyperscript')
 var suggest = require('../')
 
-var textarea = TA = h('textarea', {rows: 60, columns: 20})
+var textarea = TA = h('textarea', {rows: 60, columns: 20,
+  value: '\n'.repeat(55)
+})
 
 document.body.appendChild(h('style',
   '.suggest-box .selected {color: red;}'
@@ -13,6 +15,10 @@ document.body.appendChild(h('style',
 
 document.body.appendChild(h('div',
   h('h1', 'suggestbox test'),
+  h('input', {type: 'checkbox', onclick: function () {
+    this.parentNode.style.textAlign = this.checked ? 'right' : 'left'
+  }}),
+  h('br'),
   textarea,
   h('p',
     'type into the text area, and when you type "."',

--- a/index.js
+++ b/index.js
@@ -138,7 +138,16 @@ function onListMouseDown(e) {
 
 function render(box) {
   var cls = (box.options.cls) ? ('.'+box.options.cls) : ''
-  return h('.suggest-box'+cls, { style: { left: (box.x+'px'), top: (box.y+'px'), position: 'fixed' } }, [
+  var style = { left: (box.x+'px'), position: 'fixed' }
+
+  // hang the menu above or below the cursor, wherever there is more room
+  if (box.y < window.innerHeight/2) {
+    style.top = box.y + 'px'
+  } else {
+    style.bottom = (window.innerHeight - box.y + 20) + 'px'
+  }
+
+  return h('.suggest-box'+cls, { style: style }, [
     h('ul', {
       onmousemove: onListMouseMove.bind(box),
       onmouseover: onListMouseOver.bind(box),

--- a/index.js
+++ b/index.js
@@ -180,6 +180,7 @@ function activate() {
   this.active = true
   this.el = render(this)
   document.body.appendChild(this.el)
+  adjustPosition.call(this)
 }
 
 function update() {
@@ -188,6 +189,7 @@ function update() {
   var ul = this.el.querySelector('ul')
   ul.innerHTML = ''
   ul.appendChild(renderOpts(this))
+  adjustPosition.call(this)
 }
 
 function deactivate() {
@@ -228,5 +230,11 @@ function onblur(e) {
   this.deactivate()
 }
 
-
+function adjustPosition() {
+  // move the box left to fit in the viewport, if needed
+  var width = this.el.getBoundingClientRect().width
+  var rightOverflow = this.x + width - window.innerWidth
+  var rightAdjust = Math.min(this.x, Math.max(0, rightOverflow))
+  this.el.style.left = (this.x - rightAdjust) + 'px'
+}
 


### PR DESCRIPTION
These changes make suggest-box more useful when the textarea is close to the bottom and/or right of the viewport.

- If the text cursor is in the bottom half of the viewport, pop up the menu above the cursor instead of below it.
- If the menu is going to be hidden by the right of the viewport, try to move the menu towards the left to bring it into view.
- Update examples to make it easier to test these conditions